### PR TITLE
wrapping domain in ` quotes to enable e.g. hyphens in domain names

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -63,7 +63,7 @@ Query.prototype.to_sql = function(){
   query.push("SELECT");
   query.push(projection);
   query.push("FROM");
-  query.push(this.domain);
+  query.push("`"+this.domain+"`");
   if(this.expression){
     query.push("WHERE");
     query.push(this.expression.to_sql());


### PR DESCRIPTION
I've found this library useful recently - thank you!

I have some domains that contain hyphens, and apparently these require the domain to be wrapped in backticks to be valid queries. This PR takes care of that, and updates the tests to match.